### PR TITLE
fix: Social reactions blocked when addcontent capability is removed

### DIFF
--- a/classes/external.php
+++ b/classes/external.php
@@ -580,7 +580,7 @@ class mod_openstudio_external extends external_api {
                 'mode' => $mode));
         $context = context_module::instance($cmid);
         external_api::validate_context($context);
-        require_capability('mod/openstudio:addcontent', $context);
+        require_capability('mod/openstudio:view', $context);
 
         $results = array();
         $warnings = array();


### PR DESCRIPTION
## Problem

When removing the `mod/openstudio:addcontent` capability from the Student role 
(to hide the "Add new content" button), students lose the ability to perform 
social reactions (inspired, smile, favourite, request feedback), showing the error:

> "Sorry, but you do not currently have permissions to do this (Add content)."

## Root cause

`flag_content()` in `external.php` was using `addcontent` as a capability gate 
for social reactions. This is semantically incorrect — reactions are social actions 
that only require the user to be able to view content, not create it.

Additionally, the same function already validates `view` capability further down 
via `render_page_init`, making the previous check redundant.

## Fix

In `classes/external.php`, line 583:

```php
// Before
require_capability('mod/openstudio:addcontent', $context);

// After
require_capability('mod/openstudio:view', $context);
```
## Notes

- The "Add new content" button visibility is controlled separately via the
  `mod/openstudio:addcontent` capability — no code change required for that.
- Validated on Moodle 5.0.
